### PR TITLE
feat(deploy): add staging program ID for mainnet staging deployment

### DIFF
--- a/rlp/.gitignore
+++ b/rlp/.gitignore
@@ -24,3 +24,4 @@ qed.toml
 /audits
 rlp.qedspec
 .agents
+.staging-keys

--- a/rlp/programs/rlp/Cargo.toml
+++ b/rlp/programs/rlp/Cargo.toml
@@ -16,6 +16,7 @@ no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
+staging = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]

--- a/rlp/programs/rlp/src/lib.rs
+++ b/rlp/programs/rlp/src/lib.rs
@@ -9,6 +9,10 @@ pub mod helpers;
 
 use crate::instructions::*;
 
+#[cfg(feature = "staging")]
+declare_id!("GSEYK2FtDLywAoxn2mioXCft9FWH6Zn4VmKUArGyTVj8");
+
+#[cfg(not(feature = "staging"))]
 declare_id!("JrXLmS6aYJNJDVxdAfjNJE5wikT8ubf3TA9iL2JA9Av");
 
 #[program]

--- a/rlp/sdk/src/classes/PdaClient.ts
+++ b/rlp/sdk/src/classes/PdaClient.ts
@@ -19,23 +19,23 @@ import {
 import { RLP_PROGRAM_ADDRESS } from "../generated";
 
 export class PdaClient {
-  static async deriveSettings() {
+  static async deriveSettings(programAddress: Address = RLP_PROGRAM_ADDRESS) {
     return getProgramDerivedAddress({
-      programAddress: RLP_PROGRAM_ADDRESS,
+      programAddress,
       seeds: [SETTINGS_SEED],
     });
   }
 
-  static async deriveUserPermissions(address: Address) {
+  static async deriveUserPermissions(address: Address, programAddress: Address = RLP_PROGRAM_ADDRESS) {
     return getProgramDerivedAddress({
-      programAddress: RLP_PROGRAM_ADDRESS,
+      programAddress,
       seeds: [PERMISSIONS_SEED, getAddressEncoder().encode(address)],
     });
   }
 
-  static async deriveLiquidityPool(liquidityPoolId: number) {
+  static async deriveLiquidityPool(liquidityPoolId: number, programAddress: Address = RLP_PROGRAM_ADDRESS) {
     return getProgramDerivedAddress({
-      programAddress: RLP_PROGRAM_ADDRESS,
+      programAddress,
       seeds: [
         LIQUIDITY_POOL_SEED,
         getU8Encoder().encode(liquidityPoolId),
@@ -43,9 +43,9 @@ export class PdaClient {
     });
   }
 
-  static async deriveAsset(assetMint: Address) {
+  static async deriveAsset(assetMint: Address, programAddress: Address = RLP_PROGRAM_ADDRESS) {
     return getProgramDerivedAddress({
-      programAddress: RLP_PROGRAM_ADDRESS,
+      programAddress,
       seeds: [ASSET_SEED, getAddressEncoder().encode(assetMint)],
     });
   }
@@ -53,9 +53,10 @@ export class PdaClient {
   static async deriveCooldown(
     liquidityPoolId: number,
     cooldownId: number | bigint,
+    programAddress: Address = RLP_PROGRAM_ADDRESS,
   ) {
     return getProgramDerivedAddress({
-      programAddress: RLP_PROGRAM_ADDRESS,
+      programAddress,
       seeds: [
         COOLDOWN_SEED,
         getU8Encoder().encode(liquidityPoolId),
@@ -69,9 +70,9 @@ export class PdaClient {
    * builders auto-derive this when omitted, so most callers won't need it
    * directly — exposed for low-level instruction inspection.
    */
-  static async deriveEventAuthority() {
+  static async deriveEventAuthority(programAddress: Address = RLP_PROGRAM_ADDRESS) {
     return getProgramDerivedAddress({
-      programAddress: RLP_PROGRAM_ADDRESS,
+      programAddress,
       seeds: [EVENT_AUTHORITY_SEED],
     });
   }
@@ -81,9 +82,9 @@ export class PdaClient {
    * Uses the proxy program ID, not the RLP program ID. Used by NAV slash
    * setup (audit-M06).
    */
-  static async deriveProxyState(brandedMint: Address) {
+  static async deriveProxyState(brandedMint: Address, programAddress: Address = address(PROXY_PROGRAM_ADDRESS)) {
     return getProgramDerivedAddress({
-      programAddress: address(PROXY_PROGRAM_ADDRESS),
+      programAddress,
       seeds: [PROXY_STATE_SEED, getAddressEncoder().encode(brandedMint)],
     });
   }

--- a/rlp/sdk/src/constants/index.ts
+++ b/rlp/sdk/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { address } from "@solana/kit";
+
 export const SETTINGS_SEED = "settings";
 export const PERMISSIONS_SEED = "permissions";
 export const LIQUIDITY_POOL_SEED = "liquidity_pool";
@@ -26,3 +28,6 @@ export const MAX_COOLDOWN_DURATION_SECONDS = 365 * 24 * 60 * 60;
  * (audit-3 / audit-33). conf × this ≤ price (i.e., conf within ~2% of price).
  */
 export const MAX_ORACLE_CONFIDENCE_RATIO = 50;
+
+/** Mainnet staging deployment of this program — real tokens/oracles, isolated state. Pass to PdaClient overrides. */
+export const STAGING_PROGRAM_ID = address("GSEYK2FtDLywAoxn2mioXCft9FWH6Zn4VmKUArGyTVj8");


### PR DESCRIPTION
Adds a `staging` cfg feature that swaps declare_id! to a dedicated mainnet address (GSEYK2FtDLywAoxn2mioXCft9FWH6Zn4VmKUArGyTVj8), mirroring the pattern already used in reflect-proxy-program, so the program can run in isolation from production state while still reading real tokens/oracles.

PdaClient methods now take an optional programAddress override (defaulting to production), and the SDK exports STAGING_PROGRAM_ID for callers to pass in explicitly.